### PR TITLE
fix: Failed to capture structured binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 /.vscode/settings.json
+/.vscode/c_cpp_properties.json

--- a/internal/vfs/impl/mount_point.hpp
+++ b/internal/vfs/impl/mount_point.hpp
@@ -35,7 +35,7 @@ class TypedMountPoint
     : public MountPoint
     , public Proxy {
    public:
-	using TargetType = Proxy::TargetType;
+	using TargetType = typename Proxy::TargetType;
 
 	TypedMountPoint(std::shared_ptr<TargetType> attachment, std::shared_ptr<TargetType> original)
 	    : MountPoint(std::move(original))

--- a/src/copy.cpp
+++ b/src/copy.cpp
@@ -30,7 +30,7 @@ fs::filesystem_error err_create_hard_link_to_diff_fs_() {
 
 bool emplace_regular_file_into(std::shared_ptr<RegularFile const> src_r, fs::path const& src_p, Directory& dst_prev, fs::path const& dst_p, fs::copy_options opts) {
 	auto const [dst_r, ok] = dst_prev.emplace_regular_file(dst_p.filename());
-	auto const commit      = [&]() -> bool {
+	auto const commit      = [&dst_r = dst_r, &src_r = src_r]() -> bool {
         // NOLINTNEXTLINE
         assert(nullptr != dst_r.get());
         dst_r->copy_from(*src_r);


### PR DESCRIPTION
- I fixed a compilation error that failed to capture structural bindings. 
- I also added a part that specifies the typename for template-dependent members. 
- In my build environment (ubuntu 22.04, clang18) an error occurs when using the original code. 

Thank you for developing a useful library.